### PR TITLE
결제 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/hh/mirishop/orderpayment/OrderpaymentApplication.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/OrderpaymentApplication.java
@@ -2,11 +2,11 @@ package com.hh.mirishop.orderpayment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@FeignClient
+@EnableFeignClients
 @EnableJpaAuditing
 public class OrderpaymentApplication {
 

--- a/src/main/java/com/hh/mirishop/orderpayment/client/ProductServiceClient.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/client/ProductServiceClient.java
@@ -13,9 +13,9 @@ public interface ProductServiceClient {
     @GetMapping("/api/v1/internal/products/{productId}")
     ProductResponse getProductById(@PathVariable("productId") Long productId);
 
-    @PostMapping("/api/v1/internal/stock/decrease")
+    @PostMapping("/api/v1/internal/stocks/decrease")
     void decreaseStock(@RequestParam("productId") Long productId, @RequestParam("count") int count);
 
-    @PostMapping("/api/v1/internal/stock/restore")
+    @PostMapping("/api/v1/internal/stocks/restore")
     void restoreStock(@RequestParam("productId") Long productId, @RequestParam("count") int count);
 }

--- a/src/main/java/com/hh/mirishop/orderpayment/common/exception/ErrorCode.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     // order 에러 관련
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문이 존재하지 않습니다."),
     ORDER_STATUS_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 주문입니다."),
+    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "주문 상태가 올바르지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/hh/mirishop/orderpayment/order/controller/OrderController.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/order/controller/OrderController.java
@@ -4,6 +4,7 @@ package com.hh.mirishop.orderpayment.order.controller;
 import com.hh.mirishop.orderpayment.common.dto.BaseResponse;
 import com.hh.mirishop.orderpayment.order.dto.OrderAddressDto;
 import com.hh.mirishop.orderpayment.order.dto.OrderCreate;
+import com.hh.mirishop.orderpayment.order.dto.OrderDto;
 import com.hh.mirishop.orderpayment.order.enttiy.Order;
 import com.hh.mirishop.orderpayment.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
@@ -34,10 +35,10 @@ public class OrderController {
     }
 
     @GetMapping("/{orderId}")
-    public ResponseEntity<BaseResponse<Void>> getOrder(@RequestBody OrderCreate orderCreate,
-                                                       @RequestHeader(name = "X-MEMBER-NUMBER") Long currentMemberNumber) {
-        orderService.createOrder(orderCreate, currentMemberNumber);
-        return ResponseEntity.ok(BaseResponse.of("결재 준비중 주문 생성 완료", true, null));
+    public ResponseEntity<BaseResponse<OrderDto>> getOrder(@PathVariable("orderId") Long orderId,
+                                                           @RequestHeader(name = "X-MEMBER-NUMBER") Long currentMemberNumber) {
+        OrderDto orderByMemberNumber = orderService.findOrderByMemberNumber(orderId);
+        return ResponseEntity.ok(BaseResponse.of("주문 단건 조회 완료", true, orderByMemberNumber));
     }
 
     @PutMapping("/{orderId}/address")

--- a/src/main/java/com/hh/mirishop/orderpayment/order/controller/OrderController.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/order/controller/OrderController.java
@@ -4,8 +4,11 @@ package com.hh.mirishop.orderpayment.order.controller;
 import com.hh.mirishop.orderpayment.common.dto.BaseResponse;
 import com.hh.mirishop.orderpayment.order.dto.OrderAddressDto;
 import com.hh.mirishop.orderpayment.order.dto.OrderCreate;
+import com.hh.mirishop.orderpayment.order.enttiy.Order;
 import com.hh.mirishop.orderpayment.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,7 +35,7 @@ public class OrderController {
 
     @GetMapping("/{orderId}")
     public ResponseEntity<BaseResponse<Void>> getOrder(@RequestBody OrderCreate orderCreate,
-                                                     @RequestHeader(name = "X-MEMBER-NUMBER") Long currentMemberNumber) {
+                                                       @RequestHeader(name = "X-MEMBER-NUMBER") Long currentMemberNumber) {
         orderService.createOrder(orderCreate, currentMemberNumber);
         return ResponseEntity.ok(BaseResponse.of("결재 준비중 주문 생성 완료", true, null));
     }
@@ -48,13 +51,21 @@ public class OrderController {
     public ResponseEntity<BaseResponse<Void>> cancelOrder(@PathVariable("orderId") Long orderId,
                                                           @RequestHeader(name = "X-MEMBER-NUMBER") Long currentMemberNumber) {
         orderService.completeOrder(orderId, currentMemberNumber);
-        return ResponseEntity.ok(BaseResponse.of("주문 취소 완료", true, null));
+        return ResponseEntity.ok(BaseResponse.of("최종 주문 완료", true, null));
     }
 
     @PostMapping("/{orderId}/cancel")
     public ResponseEntity<BaseResponse<Void>> completeOrder(@PathVariable("orderId") Long orderId,
                                                             @RequestHeader(name = "X-MEMBER-NUMBER") Long currentMemberNumber) {
         orderService.cancelOrder(orderId, currentMemberNumber);
-        return ResponseEntity.ok(BaseResponse.of("최종 주문 완료", true, null));
+        return ResponseEntity.ok(BaseResponse.of("주문 취소 완료", true, null));
+    }
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<Page<Order>>> findAllOrders(
+            @RequestHeader(name = "X-MEMBER-NUMBER") Long currentMemberNumber,
+            Pageable pageable) {
+        Page<Order> orders = orderService.findAllOrdersByMemberNumber(currentMemberNumber, pageable);
+        return ResponseEntity.ok(BaseResponse.of("전체 주문 조회", true, orders));
     }
 }

--- a/src/main/java/com/hh/mirishop/orderpayment/order/controller/OrderController.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/order/controller/OrderController.java
@@ -2,12 +2,15 @@ package com.hh.mirishop.orderpayment.order.controller;
 
 
 import com.hh.mirishop.orderpayment.common.dto.BaseResponse;
+import com.hh.mirishop.orderpayment.order.dto.OrderAddressDto;
 import com.hh.mirishop.orderpayment.order.dto.OrderCreate;
 import com.hh.mirishop.orderpayment.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,22 +18,43 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/orders")
 public class OrderController {
 
     private final OrderService orderService;
 
-    @PostMapping("/order")
+    @PostMapping
     public ResponseEntity<BaseResponse<Void>> create(@RequestBody OrderCreate orderCreate,
                                                      @RequestHeader(name = "X-MEMBER-NUMBER") Long currentMemberNumber) {
         orderService.createOrder(orderCreate, currentMemberNumber);
-        return ResponseEntity.ok(BaseResponse.of("주문 생성 완료", true, null));
+        return ResponseEntity.ok(BaseResponse.of("결재 준비중 주문 생성 완료", true, null));
     }
 
-    @PostMapping("/orders/{orderId}/cancel")
+    @GetMapping("/{orderId}")
+    public ResponseEntity<BaseResponse<Void>> getOrder(@RequestBody OrderCreate orderCreate,
+                                                     @RequestHeader(name = "X-MEMBER-NUMBER") Long currentMemberNumber) {
+        orderService.createOrder(orderCreate, currentMemberNumber);
+        return ResponseEntity.ok(BaseResponse.of("결재 준비중 주문 생성 완료", true, null));
+    }
+
+    @PutMapping("/{orderId}/address")
+    public ResponseEntity<BaseResponse<Void>> addAddressToOrder(@PathVariable("orderId") Long orderId,
+                                                                @RequestBody OrderAddressDto orderAddress) {
+        orderService.addAddressToOrder(orderId, orderAddress);
+        return ResponseEntity.ok(BaseResponse.of("주문에 주소 입력 완료", true, null));
+    }
+
+    @PutMapping("/{orderId}/complete")
     public ResponseEntity<BaseResponse<Void>> cancelOrder(@PathVariable("orderId") Long orderId,
                                                           @RequestHeader(name = "X-MEMBER-NUMBER") Long currentMemberNumber) {
-        orderService.cancelOrder(orderId, currentMemberNumber);
+        orderService.completeOrder(orderId, currentMemberNumber);
         return ResponseEntity.ok(BaseResponse.of("주문 취소 완료", true, null));
+    }
+
+    @PostMapping("/{orderId}/cancel")
+    public ResponseEntity<BaseResponse<Void>> completeOrder(@PathVariable("orderId") Long orderId,
+                                                            @RequestHeader(name = "X-MEMBER-NUMBER") Long currentMemberNumber) {
+        orderService.cancelOrder(orderId, currentMemberNumber);
+        return ResponseEntity.ok(BaseResponse.of("최종 주문 완료", true, null));
     }
 }

--- a/src/main/java/com/hh/mirishop/orderpayment/order/domain/OrderStatus.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/order/domain/OrderStatus.java
@@ -1,7 +1,9 @@
 package com.hh.mirishop.orderpayment.order.domain;
 
 public enum OrderStatus {
-    ORDER,
+
+    PAYMENT_WAITING,
+    COMPLETE_ORDER,
     CANCEL,
     ;
 }

--- a/src/main/java/com/hh/mirishop/orderpayment/order/dto/OrderAddressDto.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/order/dto/OrderAddressDto.java
@@ -1,0 +1,9 @@
+package com.hh.mirishop.orderpayment.order.dto;
+
+import lombok.Getter;
+
+@Getter
+public class OrderAddressDto {
+
+    private String address;
+}

--- a/src/main/java/com/hh/mirishop/orderpayment/order/dto/OrderDto.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/order/dto/OrderDto.java
@@ -11,13 +11,14 @@ import java.util.List;
 public class OrderDto {
 
     private Long orderId;
-    private String name;
+    private Long memberNumber;
     private LocalDateTime orderDate;
     private OrderStatus status;
     private List<OrderItemDto> orderItems;
 
     public OrderDto(Order order) {
         this.orderId = order.getOrderId();
+        this.memberNumber = order.getMemberNumber();
         this.orderDate = order.getOrderDate();
         this.status = order.getStatus();
         this.orderItems = order.getOrderItems().stream()

--- a/src/main/java/com/hh/mirishop/orderpayment/order/dto/OrderItemDto.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/order/dto/OrderItemDto.java
@@ -6,13 +6,13 @@ import lombok.Getter;
 @Getter
 public class OrderItemDto {
 
-    private String itemName;
-    private int orderPrice;
+    private Long productId;
+    private Long orderPrice;
     private int count;
 
     public OrderItemDto(OrderItem orderItem) {
-//        this.itemName = orderItem.getProductId();
-//        this.orderPrice = orderItem.getOrderPrice();
-//        this.count = orderItem.getCount();
+        this.productId = orderItem.getProductId();
+        this.orderPrice = orderItem.getOrderPrice();
+        this.count = orderItem.getCount();
     }
 }

--- a/src/main/java/com/hh/mirishop/orderpayment/order/enttiy/OrderItem.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/order/enttiy/OrderItem.java
@@ -1,5 +1,6 @@
 package com.hh.mirishop.orderpayment.order.enttiy;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -29,6 +30,7 @@ public class OrderItem {
     private Long productId;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
     @JoinColumn(name = "order_id")
     private Order order;
 

--- a/src/main/java/com/hh/mirishop/orderpayment/order/repository/OrderRepository.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/order/repository/OrderRepository.java
@@ -1,18 +1,20 @@
 package com.hh.mirishop.orderpayment.order.repository;
 
 import com.hh.mirishop.orderpayment.order.enttiy.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
     @Query("SELECT o FROM Order o WHERE o.memberNumber = :memberNumber")
-    List<Order> findAllWithMember(Long memberNumber);
+    Page<Order> findAllByMemberNumber(@Param("memberNumber") Long memberNumber, Pageable pageable);
 
     Optional<Order> findByOrderIdAndMemberNumber(Long orderId, Long memberNumber);
 }

--- a/src/main/java/com/hh/mirishop/orderpayment/order/service/OrderService.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/order/service/OrderService.java
@@ -1,5 +1,6 @@
 package com.hh.mirishop.orderpayment.order.service;
 
+import com.hh.mirishop.orderpayment.order.dto.OrderAddressDto;
 import com.hh.mirishop.orderpayment.order.dto.OrderCreate;
 import com.hh.mirishop.orderpayment.order.enttiy.Order;
 
@@ -8,6 +9,10 @@ import java.util.List;
 public interface OrderService {
 
     Long createOrder(OrderCreate orderCreate, Long currentMemberNumber);
+
+    void addAddressToOrder(Long orderId, OrderAddressDto address);
+
+    void completeOrder(Long orderId, Long currentMemberNumber);
 
     void cancelOrder(Long orderId, Long currentMemberNumber);
 

--- a/src/main/java/com/hh/mirishop/orderpayment/order/service/OrderService.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/order/service/OrderService.java
@@ -2,11 +2,16 @@ package com.hh.mirishop.orderpayment.order.service;
 
 import com.hh.mirishop.orderpayment.order.dto.OrderAddressDto;
 import com.hh.mirishop.orderpayment.order.dto.OrderCreate;
+import com.hh.mirishop.orderpayment.order.dto.OrderDto;
 import com.hh.mirishop.orderpayment.order.enttiy.Order;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface OrderService {
+
+    Page<Order> findAllOrdersByMemberNumber(Long memberNumber, Pageable pageable);
+
+    OrderDto findOrderByMemberNumber(Long orderId);
 
     Long createOrder(OrderCreate orderCreate, Long currentMemberNumber);
 
@@ -15,6 +20,4 @@ public interface OrderService {
     void completeOrder(Long orderId, Long currentMemberNumber);
 
     void cancelOrder(Long orderId, Long currentMemberNumber);
-
-    Page<Order> findAllOrdersByMemberNumber(Long memberNumber, Pageable pageable);
 }

--- a/src/main/java/com/hh/mirishop/orderpayment/order/service/OrderService.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/order/service/OrderService.java
@@ -3,8 +3,8 @@ package com.hh.mirishop.orderpayment.order.service;
 import com.hh.mirishop.orderpayment.order.dto.OrderAddressDto;
 import com.hh.mirishop.orderpayment.order.dto.OrderCreate;
 import com.hh.mirishop.orderpayment.order.enttiy.Order;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderService {
 
@@ -16,5 +16,5 @@ public interface OrderService {
 
     void cancelOrder(Long orderId, Long currentMemberNumber);
 
-    List<Order> findAllOrdersByMemberNumber(Long memberNumber);
+    Page<Order> findAllOrdersByMemberNumber(Long memberNumber, Pageable pageable);
 }

--- a/src/main/java/com/hh/mirishop/orderpayment/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/order/service/OrderServiceImpl.java
@@ -12,10 +12,10 @@ import com.hh.mirishop.orderpayment.order.enttiy.Order;
 import com.hh.mirishop.orderpayment.order.enttiy.OrderItem;
 import com.hh.mirishop.orderpayment.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -112,9 +112,10 @@ public class OrderServiceImpl implements OrderService {
     /**
      * 주문 조회
      */
+    @Override
     @Transactional(readOnly = true)
-    public List<Order> findAllOrdersByMemberNumber(Long memberNumber) {
-        return orderRepository.findAllWithMember(memberNumber);
+    public Page<Order> findAllOrdersByMemberNumber(Long memberNumber, Pageable pageable) {
+        return orderRepository.findAllByMemberNumber(memberNumber, pageable);
     }
 
     private void validateOrder(Order order) {

--- a/src/main/java/com/hh/mirishop/orderpayment/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/order/service/OrderServiceImpl.java
@@ -8,6 +8,7 @@ import com.hh.mirishop.orderpayment.common.exception.OrderException;
 import com.hh.mirishop.orderpayment.order.domain.OrderStatus;
 import com.hh.mirishop.orderpayment.order.dto.OrderAddressDto;
 import com.hh.mirishop.orderpayment.order.dto.OrderCreate;
+import com.hh.mirishop.orderpayment.order.dto.OrderDto;
 import com.hh.mirishop.orderpayment.order.enttiy.Order;
 import com.hh.mirishop.orderpayment.order.enttiy.OrderItem;
 import com.hh.mirishop.orderpayment.order.repository.OrderRepository;
@@ -16,6 +17,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -26,7 +29,29 @@ public class OrderServiceImpl implements OrderService {
     private final OrderRepository orderRepository;
 
     /**
-     * 주문
+     * 전체 주문 조회
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Order> findAllOrdersByMemberNumber(Long memberNumber, Pageable pageable) {
+        return orderRepository.findAllByMemberNumber(memberNumber, pageable);
+    }
+
+    /**
+     * 주문 조회
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public OrderDto findOrderByMemberNumber(Long orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new OrderException(ErrorCode.ORDER_NOT_FOUND));
+
+        OrderDto orderDto = new OrderDto(order);
+        return orderDto;
+    }
+
+    /**
+     * 주문 생성
      */
     @Override
     @Transactional
@@ -107,15 +132,6 @@ public class OrderServiceImpl implements OrderService {
         });
 
         orderRepository.save(order);
-    }
-
-    /**
-     * 주문 조회
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public Page<Order> findAllOrdersByMemberNumber(Long memberNumber, Pageable pageable) {
-        return orderRepository.findAllByMemberNumber(memberNumber, pageable);
     }
 
     private void validateOrder(Order order) {

--- a/src/main/java/com/hh/mirishop/orderpayment/payment/controller/PaymentController.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/payment/controller/PaymentController.java
@@ -2,10 +2,13 @@ package com.hh.mirishop.orderpayment.payment.controller;
 
 import com.hh.mirishop.orderpayment.common.dto.BaseResponse;
 import com.hh.mirishop.orderpayment.payment.dto.PaymentCreate;
+import com.hh.mirishop.orderpayment.payment.dto.PaymentResponse;
 import com.hh.mirishop.orderpayment.payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,9 +20,10 @@ public class PaymentController {
     private final PaymentService paymentService;
 
     @PostMapping
-    public ResponseEntity<BaseResponse<Void>> process(PaymentCreate paymentCreate) {
-        paymentService.createPayment(paymentCreate.getOrderId(), paymentCreate.getMemberNumber());
+    public ResponseEntity<BaseResponse<PaymentResponse>> process(@RequestBody PaymentCreate paymentCreate,
+                                                                 @RequestHeader(name = "X-MEMBER-NUMBER") Long currentMemberNumber) {
+        PaymentResponse payment = paymentService.createPayment(paymentCreate.getOrderId(), currentMemberNumber);
 
-        return ResponseEntity.ok(BaseResponse.of("결제 성공", true, null));
+        return ResponseEntity.ok(BaseResponse.of("결제 성공", true, payment));
     }
 }

--- a/src/main/java/com/hh/mirishop/orderpayment/payment/controller/PaymentController.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/payment/controller/PaymentController.java
@@ -1,4 +1,25 @@
 package com.hh.mirishop.orderpayment.payment.controller;
 
+import com.hh.mirishop.orderpayment.common.dto.BaseResponse;
+import com.hh.mirishop.orderpayment.payment.dto.PaymentCreate;
+import com.hh.mirishop.orderpayment.payment.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
 public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<Void>> process(PaymentCreate paymentCreate) {
+        paymentService.createPayment(paymentCreate.getOrderId(), paymentCreate.getMemberNumber());
+
+        return ResponseEntity.ok(BaseResponse.of("결제 성공", true, null));
+    }
 }

--- a/src/main/java/com/hh/mirishop/orderpayment/payment/dto/PaymentCreate.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/payment/dto/PaymentCreate.java
@@ -1,0 +1,12 @@
+package com.hh.mirishop.orderpayment.payment.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PaymentCreate {
+
+    private Long orderId;
+    private Long memberNumber;
+}

--- a/src/main/java/com/hh/mirishop/orderpayment/payment/dto/PaymentCreate.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/payment/dto/PaymentCreate.java
@@ -8,5 +8,4 @@ import lombok.NoArgsConstructor;
 public class PaymentCreate {
 
     private Long orderId;
-    private Long memberNumber;
 }

--- a/src/main/java/com/hh/mirishop/orderpayment/payment/dto/PaymentResponse.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/payment/dto/PaymentResponse.java
@@ -1,0 +1,20 @@
+package com.hh.mirishop.orderpayment.payment.dto;
+
+import com.hh.mirishop.orderpayment.payment.entity.Payment;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PaymentResponse {
+
+    private Long orderId;
+    private Long paymentId;
+    private LocalDateTime createdAt;
+
+    public PaymentResponse(Payment payment) {
+        this.orderId = payment.getOrder().getOrderId();
+        this.paymentId = payment.getPaymentId();
+        this.createdAt = payment.getCreatedAt();
+    }
+}

--- a/src/main/java/com/hh/mirishop/orderpayment/payment/entity/Payment.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/payment/entity/Payment.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hh.mirishop.orderpayment.order.enttiy.Order;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,6 +18,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -26,6 +28,7 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Payment {
 
     @Id
@@ -33,7 +36,7 @@ public class Payment {
     @Column(name ="payment_id")
     private Long paymentId;
 
-    @Column(name = "member_number", nullable = false)
+    @Column(name = "member_number")
     private Long memberNumber;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/hh/mirishop/orderpayment/payment/entity/Payment.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/payment/entity/Payment.java
@@ -1,4 +1,52 @@
 package com.hh.mirishop.orderpayment.payment.entity;
 
+import com.hh.mirishop.orderpayment.order.enttiy.Order;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payment")
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Payment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name ="payment_id")
+    private Long paymentId;
+
+    @Column(name = "member_number", nullable = false)
+    private Long memberNumber;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", referencedColumnName = "order_id")
+    private Order order;
+
+    @Column(name = "created_at")
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(name = "is_deleted")
+    private Boolean isDeleted;
+
+    public void linkOrder(Order order) {
+        this.order = order;
+    }
 }

--- a/src/main/java/com/hh/mirishop/orderpayment/payment/entity/Payment.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/payment/entity/Payment.java
@@ -1,5 +1,6 @@
 package com.hh.mirishop.orderpayment.payment.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hh.mirishop.orderpayment.order.enttiy.Order;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -36,6 +37,7 @@ public class Payment {
     private Long memberNumber;
 
     @OneToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
     @JoinColumn(name = "order_id", referencedColumnName = "order_id")
     private Order order;
 

--- a/src/main/java/com/hh/mirishop/orderpayment/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/payment/repository/PaymentRepository.java
@@ -1,0 +1,15 @@
+package com.hh.mirishop.orderpayment.payment.repository;
+
+import com.hh.mirishop.orderpayment.payment.entity.Payment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    Optional<Payment> findById(Long paymentId);
+
+    Page<Payment> findAll(Pageable pageable);
+}

--- a/src/main/java/com/hh/mirishop/orderpayment/payment/service/PaymentService.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/payment/service/PaymentService.java
@@ -1,6 +1,8 @@
 package com.hh.mirishop.orderpayment.payment.service;
 
+import com.hh.mirishop.orderpayment.payment.dto.PaymentResponse;
+
 public interface PaymentService {
 
-    Long createPayment(Long orderId, Long currentMemberNumber);
+    PaymentResponse createPayment(Long orderId, Long currentMemberNumber);
 }

--- a/src/main/java/com/hh/mirishop/orderpayment/payment/service/PaymentService.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/payment/service/PaymentService.java
@@ -1,0 +1,6 @@
+package com.hh.mirishop.orderpayment.payment.service;
+
+public interface PaymentService {
+
+    Long createPayment(Long orderId, Long currentMemberNumber);
+}

--- a/src/main/java/com/hh/mirishop/orderpayment/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/payment/service/PaymentServiceImpl.java
@@ -1,0 +1,37 @@
+package com.hh.mirishop.orderpayment.payment.service;
+
+import com.hh.mirishop.orderpayment.common.exception.ErrorCode;
+import com.hh.mirishop.orderpayment.common.exception.OrderException;
+import com.hh.mirishop.orderpayment.order.enttiy.Order;
+import com.hh.mirishop.orderpayment.order.repository.OrderRepository;
+import com.hh.mirishop.orderpayment.payment.entity.Payment;
+import com.hh.mirishop.orderpayment.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentServiceImpl implements PaymentService{
+
+    private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
+
+    @Override
+    @Transactional
+    public Long createPayment(Long orderId, Long currentMemberNumber) {
+        // 주문 여부 조회
+        Order savedOrder = orderRepository.findById(orderId)
+                .orElseThrow(() -> new OrderException(ErrorCode.ORDER_NOT_FOUND));
+
+        Payment payment = Payment.builder()
+                .memberNumber(currentMemberNumber)
+                .isDeleted(false)
+                .build();
+
+        paymentRepository.save(payment);
+        savedOrder.addPayment(payment);
+
+        return payment.getPaymentId();
+    }
+}

--- a/src/main/java/com/hh/mirishop/orderpayment/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/hh/mirishop/orderpayment/payment/service/PaymentServiceImpl.java
@@ -4,6 +4,7 @@ import com.hh.mirishop.orderpayment.common.exception.ErrorCode;
 import com.hh.mirishop.orderpayment.common.exception.OrderException;
 import com.hh.mirishop.orderpayment.order.enttiy.Order;
 import com.hh.mirishop.orderpayment.order.repository.OrderRepository;
+import com.hh.mirishop.orderpayment.payment.dto.PaymentResponse;
 import com.hh.mirishop.orderpayment.payment.entity.Payment;
 import com.hh.mirishop.orderpayment.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,11 +20,10 @@ public class PaymentServiceImpl implements PaymentService{
 
     @Override
     @Transactional
-    public Long createPayment(Long orderId, Long currentMemberNumber) {
+    public PaymentResponse createPayment(Long orderId, Long currentMemberNumber) {
         // 주문 여부 조회
         Order savedOrder = orderRepository.findById(orderId)
                 .orElseThrow(() -> new OrderException(ErrorCode.ORDER_NOT_FOUND));
-
         Payment payment = Payment.builder()
                 .memberNumber(currentMemberNumber)
                 .isDeleted(false)
@@ -32,6 +32,6 @@ public class PaymentServiceImpl implements PaymentService{
         paymentRepository.save(payment);
         savedOrder.addPayment(payment);
 
-        return payment.getPaymentId();
+        return new PaymentResponse(payment);
     }
 }


### PR DESCRIPTION
## 요약
|상태|설명| 재고 선점 |
|-----|-----|:----:|
| 주문정보 | 유저가 주문을 누르면 배송정보 등 적는 페이지 진입 | O |
| 결제 중 | 유저 결제 시도(외부결제 모듈 등) | O |
| 결제 완료 | 주문정보 생성, 결제 완료를 반환 | O |

주문 버튼을 누른 순으로 재고 감소가 일어남.
재고부분에 Redisson 으로 분산락을 적용

## 상세 작업 내용
- [X] 결제 화면 진입시 우선적으로 재고 차감하는 기능
- [X] 주문완료가 아니라 결제화면 진입시 재고를 가져가도록 리팩토링
- [X] 유저 결제 기능 
- [X] 결제 완료 시 완료된 정보를 보여주는 기능
- [X] 재고기능에 락 구현하여 동시 접근 차단

Closes #2 